### PR TITLE
Allow for custom webpack config options

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "babel-register": "^6.24.1",
     "chalk": "^1.1.3",
     "chokidar": "^1.7.0",
+    "copy-webpack-plugin": "^4.0.1",
     "core-decorators": "^0.19.0",
     "css-hot-loader": "^1.3.0",
     "css-loader": "^0.28.4",

--- a/src/config/webpack.dev.js
+++ b/src/config/webpack.dev.js
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import path from 'path';
 import autoprefixer from 'autoprefixer';
 import flexbugs from 'postcss-flexbugs-fixes';
@@ -7,7 +8,114 @@ import webpackMiddleware from 'koa-webpack';
 import logger from '../shared/utils/logger';
 
 export default (app, options) => {
-  app.use(webpackMiddleware({
+  let devConfig = {
+    resolve: {
+      alias: {
+        fervorAppRoutes: path.resolve(options.appLocation, 'src', 'urls.js'),
+      },
+    },
+    entry: [
+      'react-hot-loader/patch',
+      'webpack-hot-middleware/client',
+      path.join(__dirname, '..', 'client', 'main.js'),
+    ],
+    output: {
+      path: options.appLocation,
+      publicPath: '/build/',
+      filename: 'bundle.js',
+      sourceMapFilename: 'bundle.js.map',
+    },
+    devtool: 'inline-source-map',
+    module: {
+      loaders: [
+        {
+          test: /\.json$/,
+          exclude: /node_modules/,
+          use: 'json-loader',
+        },
+        {
+          test: /\.jpe?g$|\.gif$|\.png$|\.svg$|\.woff$|\.ttf$|\.wav$|\.mp3$|\.html$/,
+          loader: 'file-loader',
+        },
+        {
+          test: /\.scss$/,
+          use: [
+            'style-loader',
+            {
+              loader: 'css-loader',
+              options: {
+                modules: true,
+                importLoaders: 2,
+                localIdentName: '[name]__[local]___[hash:base64:5]',
+              },
+            },
+            {
+              loader: 'postcss-loader',
+              options: {
+                plugins() {
+                  return [autoprefixer, flexbugs];
+                },
+              },
+            },
+            {
+              loader: 'sass-loader',
+              options: {
+                outputStyle: 'compressed',
+              },
+            },
+          ],
+        },
+        {
+          test: /\.js$/,
+          use: [
+            { loader: 'react-hot-loader/webpack' },
+            {
+              loader: 'babel-loader',
+              options: {
+                presets: ['es2015', 'react', 'stage-0'],
+                plugins: [],
+              },
+            },
+          ],
+          exclude: [/node_modules/],
+        },
+        // {
+        //   test: /\.js$|\.jsx$/,
+        //   loader: 'eslint-loader',
+        //   exclude: [/node_modules/],
+        // },
+      ],
+    },
+    plugins: [
+      new webpack.DefinePlugin({
+        __DEV__: JSON.stringify(JSON.parse(process.env.BUILD_DEV || true)),
+        'process.env': {
+          BROWSER: JSON.stringify(true),
+          HOST: JSON.stringify(process.env.HOST),
+        },
+      }),
+      new webpack.DllReferencePlugin({
+        context: path.join(__dirname, '..'),
+        // the next line requires a yarn build
+        // eslint-disable-next-line
+        manifest: require('../../lib/fervorVendors-manifest.json'),
+      }),
+      new webpack.optimize.ModuleConcatenationPlugin(),
+      new webpack.optimize.OccurrenceOrderPlugin(),
+      new webpack.HotModuleReplacementPlugin(),
+      new webpack.NoEmitOnErrorsPlugin(),
+      new webpack.NamedModulesPlugin(),
+    ],
+  };
+
+  const customConfigPath = path.join(options.appLocation, 'src', 'config', 'webpack');
+  if (fs.existsSync(`${customConfigPath}.js`)) {
+    // Server side only - this is fine
+    // eslint-disable-next-line import/no-dynamic-require, global-require
+    devConfig = require(customConfigPath).default(devConfig);
+  }
+
+  const devSetup = {
     dev: {
       publicPath: '/build/',
       headers: { 'Content-Type': 'text/html; charset=utf-8' },
@@ -20,104 +128,9 @@ export default (app, options) => {
       path: '/__webpack_hmr',
       heartbeat: 10 * 1000,
     },
-    config: {
-      resolve: {
-        alias: {
-          fervorAppRoutes: path.resolve(options.appLocation, 'src', 'urls.js'),
-        },
-      },
-      entry: [
-        'react-hot-loader/patch',
-        'webpack-hot-middleware/client',
-        path.join(__dirname, '..', 'client', 'main.js'),
-      ],
-      output: {
-        path: options.appLocation,
-        publicPath: '/build/',
-        filename: 'bundle.js',
-        sourceMapFilename: 'bundle.js.map',
-      },
-      devtool: 'inline-source-map',
-      module: {
-        loaders: [
-          {
-            test: /\.json$/,
-            exclude: /node_modules/,
-            use: 'json-loader',
-          },
-          {
-            test: /\.jpe?g$|\.gif$|\.png$|\.svg$|\.woff$|\.ttf$|\.wav$|\.mp3$|\.html$/,
-            loader: 'file-loader',
-          },
-          {
-            test: /\.scss$/,
-            use: [
-              'style-loader',
-              {
-                loader: 'css-loader',
-                options: {
-                  modules: true,
-                  importLoaders: 2,
-                  localIdentName: '[name]__[local]___[hash:base64:5]',
-                },
-              },
-              {
-                loader: 'postcss-loader',
-                options: {
-                  plugins() {
-                    return [autoprefixer, flexbugs];
-                  },
-                },
-              },
-              {
-                loader: 'sass-loader',
-                options: {
-                  outputStyle: 'compressed',
-                },
-              },
-            ],
-          },
-          {
-            test: /\.js$/,
-            use: [
-              { loader: 'react-hot-loader/webpack' },
-              {
-                loader: 'babel-loader',
-                options: {
-                  presets: ['es2015', 'react', 'stage-0'],
-                  plugins: [],
-                },
-              },
-            ],
-            exclude: [/node_modules/],
-          },
-          // {
-          //   test: /\.js$|\.jsx$/,
-          //   loader: 'eslint-loader',
-          //   exclude: [/node_modules/],
-          // },
-        ],
-      },
-      plugins: [
-        new webpack.DefinePlugin({
-          __DEV__: JSON.stringify(JSON.parse(process.env.BUILD_DEV || true)),
-          'process.env': {
-            BROWSER: JSON.stringify(true),
-            HOST: JSON.stringify(process.env.HOST),
-          },
-        }),
-        new webpack.DllReferencePlugin({
-          context: path.join(__dirname, '..'),
-          // the next line requires a yarn build
-          // eslint-disable-next-line
-          manifest: require('../../lib/fervorVendors-manifest.json'),
-        }),
-        new webpack.optimize.ModuleConcatenationPlugin(),
-        new webpack.optimize.OccurrenceOrderPlugin(),
-        new webpack.HotModuleReplacementPlugin(),
-        new webpack.NoEmitOnErrorsPlugin(),
-        new webpack.NamedModulesPlugin(),
-      ],
-    },
-  }));
+    config: devConfig,
+  };
+
+  const wpMiddleware = options.webpackMiddleware || webpackMiddleware;
+  app.use(wpMiddleware(devSetup));
 };

--- a/src/config/webpack.prod.js
+++ b/src/config/webpack.prod.js
@@ -20,6 +20,7 @@ require('babel-register')({
   ],
 });
 
+const fs = require('fs');
 const path = require('path');
 const autoprefixer = require('autoprefixer');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
@@ -48,113 +49,124 @@ if (process.env.TEST_ENV !== 'integration') {
   runtimeCaching = Object.keys(urls).map(generateCacheSettings);
 }
 
-module.exports = () => ({
-  resolve: {
-    alias: {
-      fervorAppRoutes: path.resolve(process.cwd(), 'src', 'urls.js'),
+module.exports = () => {
+  let prodConfig = {
+    resolve: {
+      alias: {
+        fervorAppRoutes: path.resolve(process.cwd(), 'src', 'urls.js'),
+      },
     },
-  },
-  entry: {
-    bundle: path.join(__dirname, '..', 'client', 'main.js'),
-  },
-  output: {
-    path: buildDir,
-    publicPath: '/build/',
-    filename: '[name]-[hash:6].js',
-  },
-  module: {
-    loaders: [
-      {
-        test: /\.json$/,
-        exclude: /node_modules/,
-        use: 'json-loader',
-      },
-      {
-        test: /\.jpe?g$|\.gif$|\.png$|\.svg$|\.woff$|\.ttf$|\.wav$|\.mp3$|\.html$/,
-        loader: 'file-loader',
-      },
-      {
-        test: /\.scss$/,
-        use: ExtractTextPlugin.extract({
-          fallback: 'style-loader',
-          use: [
-            {
-              loader: 'css-loader',
-              options: {
-                modules: true,
-                importLoaders: 2,
-                localIdentName: '[name]__[local]___[hash:base64:5]',
-              },
-            },
-            {
-              loader: 'postcss-loader',
-              options: {
-                plugins() {
-                  return [autoprefixer, flexbugs];
+    entry: {
+      bundle: path.join(__dirname, '..', 'client', 'main.js'),
+    },
+    output: {
+      path: buildDir,
+      publicPath: '/build/',
+      filename: '[name]-[hash:6].js',
+    },
+    module: {
+      loaders: [
+        {
+          test: /\.json$/,
+          exclude: /node_modules/,
+          use: 'json-loader',
+        },
+        {
+          test: /\.jpe?g$|\.gif$|\.png$|\.svg$|\.woff$|\.ttf$|\.wav$|\.mp3$|\.html$/,
+          loader: 'file-loader',
+        },
+        {
+          test: /\.scss$/,
+          use: ExtractTextPlugin.extract({
+            fallback: 'style-loader',
+            use: [
+              {
+                loader: 'css-loader',
+                options: {
+                  modules: true,
+                  importLoaders: 2,
+                  localIdentName: '[name]__[local]___[hash:base64:5]',
                 },
               },
-            },
+              {
+                loader: 'postcss-loader',
+                options: {
+                  plugins() {
+                    return [autoprefixer, flexbugs];
+                  },
+                },
+              },
+              {
+                loader: 'sass-loader',
+                options: {
+                  outputStyle: 'compressed',
+                },
+              },
+            ],
+          }),
+        },
+        {
+          test: /\.js$/,
+          use: [
             {
-              loader: 'sass-loader',
+              loader: 'babel-loader',
               options: {
-                outputStyle: 'compressed',
+                presets: ['es2015', 'react', 'stage-0'],
+                plugins: [],
               },
             },
           ],
-        }),
-      },
-      {
-        test: /\.js$/,
-        use: [
-          {
-            loader: 'babel-loader',
-            options: {
-              presets: ['es2015', 'react', 'stage-0'],
-              plugins: [],
-            },
-          },
-        ],
-        exclude: [/node_modules/],
-      },
-    ],
-  },
-  plugins: [
-    new ChunkManifestPlugin(),
-    new ExtractTextPlugin({
-      allChunks: true,
-      filename: 'bundle-[hash:6].css',
-    }),
-    new webpack.DefinePlugin({
-      __DEV__: JSON.stringify(false),
-      'process.env': {
-        NODE_ENV: JSON.stringify('production'),
-        BROWSER: JSON.stringify(true),
-        HOST: JSON.stringify(process.env.HOST),
-      },
-    }),
-    new webpack.DllReferencePlugin({
-      context: path.join(__dirname, '..'),
-      // the next line requires a yarn build
-      // eslint-disable-next-line
-      manifest: require('../../lib/fervorVendors-manifest.json'),
-    }),
-    new webpack.optimize.ModuleConcatenationPlugin(),
-    new webpack.optimize.OccurrenceOrderPlugin(),
-    new webpack.NoEmitOnErrorsPlugin(),
-    new webpack.NamedModulesPlugin(),
-    new webpack.optimize.UglifyJsPlugin({
-      parallel: true,
-      workers: 5,
-      ecma: 8,
-    }),
-    new WorkboxPlugin({
-      globDirectory: process.cwd(),
-      globPatterns: [
-        'build/**/bundle-*.{js,css}',
-        'assets/**/*.{png,jpg,jpeg,gif,woff,woff2,svg,js,css}',
+          exclude: [/node_modules/],
+        },
       ],
-      swDest: path.join(buildDir, 'sw.js'),
-      runtimeCaching,
-    }),
-  ],
-});
+    },
+    plugins: [
+      new ChunkManifestPlugin(),
+      new ExtractTextPlugin({
+        allChunks: true,
+        filename: 'bundle-[hash:6].css',
+      }),
+      new webpack.DefinePlugin({
+        __DEV__: JSON.stringify(false),
+        'process.env': {
+          NODE_ENV: JSON.stringify('production'),
+          BROWSER: JSON.stringify(true),
+          HOST: JSON.stringify(process.env.HOST),
+        },
+      }),
+      new webpack.DllReferencePlugin({
+        context: path.join(__dirname, '..'),
+        // the next line requires a yarn build
+        // eslint-disable-next-line
+        manifest: require('../../lib/fervorVendors-manifest.json'),
+      }),
+      new webpack.optimize.ModuleConcatenationPlugin(),
+      new webpack.optimize.OccurrenceOrderPlugin(),
+      new webpack.NoEmitOnErrorsPlugin(),
+      new webpack.NamedModulesPlugin(),
+      new webpack.optimize.UglifyJsPlugin({
+        parallel: true,
+        workers: 5,
+        ecma: 8,
+      }),
+      new WorkboxPlugin({
+        globDirectory: process.cwd(),
+        globPatterns: [
+          'build/**/bundle-*.{js,css}',
+          'assets/**/*.{png,jpg,jpeg,gif,woff,woff2,svg,js,css}',
+        ],
+        swDest: path.join(buildDir, 'sw.js'),
+        runtimeCaching,
+      }),
+    ],
+  };
+
+  const customConfigPath = path.join(process.cwd(), 'src', 'config', 'webpack');
+  if (fs.existsSync(`${customConfigPath}.js`)) {
+    // Server side only - this is fine
+    // eslint-disable-next-line import/no-dynamic-require, global-require
+    prodConfig = require(customConfigPath).default(prodConfig);
+  }
+
+  return prodConfig;
+};

--- a/test/integration/prod/prod.spec.js
+++ b/test/integration/prod/prod.spec.js
@@ -1,6 +1,8 @@
 import { expect } from 'chai';
 /* globals before, browser */
+import fs from 'fs';
 import path from 'path';
+import rimraf from 'rimraf';
 import dotenv from 'dotenv';
 import superagent from 'superagent';
 import buildApp from '../../../src/cli/commands/build';
@@ -8,6 +10,7 @@ import startApp from '../../../src/server/server';
 
 describe('Prod server', () => {
   before(async () => {
+    rimraf.sync(path.join(__dirname, 'testApp', 'build'));
     dotenv.config({ path: path.join(process.cwd(), 'test', 'integration', 'prod', 'testApp', '.env') });
     await buildApp({
       babel: path.join(process.cwd(), 'node_modules', 'babel-cli', 'bin', 'babel.js'),
@@ -46,5 +49,11 @@ describe('Prod server', () => {
         .getCssProperty('div[class*="component"]', 'color')
         .value.indexOf('rgba(255,255,255,1)') >= -1
     ), 20000);
+  });
+
+  it('respects the custom webpack config', () => {
+    expect(
+      fs.statSync(path.join(__dirname, 'testApp', 'build', 'test123.js')).isFile(),
+    ).to.equal(true);
   });
 });

--- a/test/integration/prod/testApp/src/config/test123.js
+++ b/test/integration/prod/testApp/src/config/test123.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line
+console.log('hi');

--- a/test/integration/prod/testApp/src/config/webpack.js
+++ b/test/integration/prod/testApp/src/config/webpack.js
@@ -1,0 +1,9 @@
+import CopyPlugin from 'copy-webpack-plugin';
+
+export default (config) => {
+  config.plugins.push(CopyPlugin([
+    { from: `${__dirname}/test123.js` },
+  ]));
+
+  return config;
+};

--- a/test/unit/config/src/urls.js
+++ b/test/unit/config/src/urls.js
@@ -1,0 +1,1 @@
+export default {};

--- a/test/unit/config/webpack.dev.spec.js
+++ b/test/unit/config/webpack.dev.spec.js
@@ -1,0 +1,52 @@
+import fs from 'fs';
+import path from 'path';
+import webPackDevConfig from '../../../src/config/webpack.dev';
+
+let pluginCount;
+
+describe('Webpack Dev Config, without a custom config', () => {
+  it('returns a config', async () => {
+    webPackDevConfig(
+      { use: () => {} },
+      {
+        appLocation: __dirname,
+        webpackMiddleware: (cfg) => {
+          expect(typeof cfg.dev).toBe('object');
+          expect(typeof cfg.config).toBe('object');
+          pluginCount = cfg.config.plugins.length;
+        },
+      },
+    );
+  });
+});
+
+describe('Webpack Dev Config, with a custom config', () => {
+  beforeEach(() => {
+    fs.writeFileSync(
+    path.join(__dirname, 'src', 'config', 'webpack.js'),
+    `
+      import CopyPlugin from 'copy-webpack-plugin';
+
+      export default (config) => {
+        config.plugins.push(CopyPlugin([]));
+        return config;
+      };
+    `);
+  });
+
+  afterEach(() => {
+    fs.unlinkSync(path.join(__dirname, 'src', 'config', 'webpack.js'));
+  });
+
+  it('returns a config', async () => {
+    webPackDevConfig(
+      { use: () => {} },
+      {
+        appLocation: __dirname,
+        webpackMiddleware: (cfg) => {
+          expect(cfg.config.plugins.length).toBe(pluginCount + 1);
+        },
+      },
+    );
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1191,6 +1191,10 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
+bluebird@^2.10.2:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-2.11.0.tgz#534b9033c022c9579c56ba3b3e5a5caafbb650e1"
+
 bluebird@^3.4.6:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.0.tgz#791420d7f551eea2897453a8a77653f96606d67c"
@@ -1793,6 +1797,19 @@ cookies@~0.6.1:
   dependencies:
     depd "~1.1.0"
     keygrip "~1.0.1"
+
+copy-webpack-plugin@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/copy-webpack-plugin/-/copy-webpack-plugin-4.0.1.tgz#9728e383b94316050d0c7463958f2b85c0aa8200"
+  dependencies:
+    bluebird "^2.10.2"
+    fs-extra "^0.26.4"
+    glob "^6.0.4"
+    is-glob "^3.1.0"
+    loader-utils "^0.2.15"
+    lodash "^4.3.0"
+    minimatch "^3.0.0"
+    node-dir "^0.1.10"
 
 core-decorators@^0.19.0:
   version "0.19.0"
@@ -3042,6 +3059,16 @@ fs-exists-sync@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz#982d6893af918e72d08dec9e8673ff2b5a8d6add"
 
+fs-extra@^0.26.4:
+  version "0.26.7"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-0.26.7.tgz#9ae1fdd94897798edab76d0918cf42d0c3184fa9"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^2.1.0"
+    klaw "^1.0.0"
+    path-is-absolute "^1.0.0"
+    rimraf "^2.2.8"
+
 fs-extra@^0.30.0:
   version "0.30.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-0.30.0.tgz#f233ffcc08d4da7d432daa449776989db1df93f0"
@@ -3190,6 +3217,16 @@ glob@7.1.1:
     inflight "^1.0.4"
     inherits "2"
     minimatch "^3.0.2"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^6.0.4:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-6.0.4.tgz#0f08860f6a155127b2fadd4f9ce24b1aab6e4d22"
+  dependencies:
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "2 || 3"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
@@ -4636,7 +4673,7 @@ loader-runner@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.3.0.tgz#f482aea82d543e07921700d5a46ef26fdac6b8a2"
 
-loader-utils@^0.2.16:
+loader-utils@^0.2.15, loader-utils@^0.2.16:
   version "0.2.17"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-0.2.17.tgz#f86e6374d43205a6e6c60e9196f17c0299bfb348"
   dependencies:
@@ -5007,7 +5044,7 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
 
-minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4, minimatch@~3.0.2:
+"minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4, minimatch@~3.0.2:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
@@ -5118,6 +5155,12 @@ natural-compare@^1.4.0:
 negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
+
+node-dir@^0.1.10:
+  version "0.1.17"
+  resolved "https://registry.yarnpkg.com/node-dir/-/node-dir-0.1.17.tgz#5f5665d93351335caabef8f1c554516cf5f1e4e5"
+  dependencies:
+    minimatch "^3.0.2"
 
 node-fetch@^1.0.1:
   version "1.7.2"


### PR DESCRIPTION
Lots of great use cases for this. A few include being able
to swap out react for inferno or preact. Another may
include the ability to copy some other files at build time
into some folder. In any case, you *may* at time need some
custom webpack config.

The way we go about it here, allows individuals to merge
or replace pieces of both the dev and prod webpack configs.
While they are different, we hope that we can keep this relatively
simple for now and ask for a single webpack config to affect
both dev and prod safely.