### PR TITLE
Custom Koa middleware

### DIFF
--- a/test/integration/dev/dev.spec.js
+++ b/test/integration/dev/dev.spec.js
@@ -38,4 +38,9 @@ describe('Dev server', () => {
         .value.indexOf('rgba(255,255,255,1)') >= -1
     ), 10000);
   });
+
+  it('renders custom middleware', async () => {
+    const response = await superagent.get('http://localhost:3002/pizza');
+    expect(response.text).to.contain('Pizza World');
+  });
 });

--- a/test/integration/dev/testApp/src/middleware.js
+++ b/test/integration/dev/testApp/src/middleware.js
@@ -1,0 +1,11 @@
+import KoaRouter from 'koa-router';
+
+export default ({ app }) => {
+  const router = new KoaRouter();
+
+  router.get('/pizza', async (ctx) => {
+    ctx.body = 'Pizza World';
+  });
+
+  app.use(router.routes());
+};

--- a/test/integration/prod/prod.spec.js
+++ b/test/integration/prod/prod.spec.js
@@ -56,4 +56,9 @@ describe('Prod server', () => {
       fs.statSync(path.join(__dirname, 'testApp', 'build', 'test123.js')).isFile(),
     ).to.equal(true);
   });
+
+  it('renders custom middleware', async () => {
+    const response = await superagent.get('http://localhost:3003/pizza');
+    expect(response.text).to.contain('Pizza World');
+  });
 });

--- a/test/integration/prod/testApp/src/middleware/index.js
+++ b/test/integration/prod/testApp/src/middleware/index.js
@@ -1,0 +1,5 @@
+import pizza from './pizza';
+
+export default ({ app }) => {
+  app.use(pizza());
+};

--- a/test/integration/prod/testApp/src/middleware/pizza.js
+++ b/test/integration/prod/testApp/src/middleware/pizza.js
@@ -1,0 +1,11 @@
+import KoaRouter from 'koa-router';
+
+export default () => {
+  const router = new KoaRouter();
+
+  router.get('/pizza', async (ctx) => {
+    ctx.body = 'Pizza World';
+  });
+
+  return router.routes();
+};


### PR DESCRIPTION
Sometimes users may find the need to add custom middleware.
This allows those users to add a middleware folder or file
and then allows them to do anything from add "restful" endpoints
to adding other custom tools. The middleware will be passed
the app, environment vars and the logger.