### PR TITLE
Allow custom babelrc files

### DIFF
--- a/src/cli/commands/build.js
+++ b/src/cli/commands/build.js
@@ -1,9 +1,10 @@
 const { execSync } = require('child_process');
+const fs = require('fs');
 const path = require('path');
+const babelrcHelper = require('../../config/babelrcHelper').default;
 
 module.exports = ({
   directory = process.cwd(),
-  fervorDir = path.join(directory, 'node_modules', 'fervor'),
   babel = path.join(directory, 'node_modules', 'babel-cli', 'bin', 'babel.js'),
   webpack = path.join(directory, 'node_modules', 'webpack', 'bin', 'webpack.js'),
   isIntegrationTest = false,
@@ -11,9 +12,10 @@ module.exports = ({
   // build for server, using babel
   const srcFolder = path.join(directory, 'src');
   const builtFolder = path.join(directory, 'build');
-  const babelrcFervor = path.join(fervorDir, '.babelrc');
   const babelrcSrc = path.join(directory, '.babelrc');
-  execSync(`cp ${babelrcFervor} ${babelrcSrc}`);
+  const config = babelrcHelper(true, directory, true);
+
+  fs.writeFileSync(babelrcSrc, JSON.stringify(config), 'utf8');
   execSync(`${babel} ${srcFolder} -d ${builtFolder}`);
   execSync(`rm ${babelrcSrc}`);
 

--- a/src/cli/commands/startDev.js
+++ b/src/cli/commands/startDev.js
@@ -4,7 +4,7 @@ const dotenv = require('dotenv');
 // const chokidar = require('chokidar');
 require('isomorphic-fetch');
 require('babel-polyfill');
-require('babel-register')(require('../../config/babelrcHelper').default(true));
+require('babel-register')(require('../../config/babelrcHelper').default(true, process.cwd(), true));
 const startApp = require('../../server/server').default;
 
 module.exports = (args) => {

--- a/src/config/babelrcHelper.js
+++ b/src/config/babelrcHelper.js
@@ -1,5 +1,8 @@
-export default (isServer) => {
-  const output = {
+import fs from 'fs';
+import path from 'path';
+
+export default (isServer, appLocation, useSrc) => {
+  let config = {
     presets: [
       ['env', { targets: { browsers: ['last 2 versions', 'safari >= 7'] } }],
       'react',
@@ -9,7 +12,7 @@ export default (isServer) => {
   };
 
   if (isServer) {
-    output.plugins = [
+    config.plugins = [
       [
         'css-modules-transform',
         {
@@ -23,5 +26,19 @@ export default (isServer) => {
     ];
   }
 
-  return output;
+  if (appLocation === false) {
+    return config;
+  }
+
+  const customConfigPathSrc = path.join(appLocation, 'src', 'config', 'babel.js');
+  const customConfigPathBuild = path.join(appLocation, 'build', 'config', 'babel.js');
+  if (useSrc && fs.existsSync(customConfigPathSrc)) {
+    // eslint-disable-next-line global-require, import/no-dynamic-require
+    config = require(`${appLocation}/src/config/babel`).default(config, isServer);
+  } else if (fs.existsSync(customConfigPathBuild)) {
+    // eslint-disable-next-line global-require, import/no-dynamic-require
+    config = require(`${appLocation}/build/config/babel`).default(config, isServer);
+  }
+
+  return config;
 };

--- a/src/config/webpack.dev.js
+++ b/src/config/webpack.dev.js
@@ -72,7 +72,11 @@ export default (app, options) => {
             {
               loader: 'babel-loader',
               // eslint-disable-next-line global-require
-              options: require('./babelrcHelper').default(false),
+              options: require('./babelrcHelper').default(
+                false,
+                options.appLocation,
+                true,
+              ),
             },
           ],
           exclude: [/node_modules/],

--- a/src/config/webpack.prod.js
+++ b/src/config/webpack.prod.js
@@ -1,6 +1,6 @@
 require('isomorphic-fetch');
 require('babel-polyfill');
-require('babel-register')(require('./babelrcHelper').default(true));
+require('babel-register')(require('./babelrcHelper').default(true, false));
 
 const fs = require('fs');
 const path = require('path');
@@ -11,7 +11,7 @@ const flexbugs = require('postcss-flexbugs-fixes');
 const webpack = require('webpack');
 const WorkboxPlugin = require('workbox-webpack-plugin');
 const ChunkManifestPlugin = require('./ChunkManifestPlugin');
-const clientSideBabelConfig = require('./babelrcHelper').default(false);
+const clientSideBabelConfig = require('./babelrcHelper').default(false, process.cwd(), true);
 
 const buildDir = path.join(process.cwd(), 'build');
 

--- a/test/integration/dev/testApp/src/apps/Hello.js
+++ b/test/integration/dev/testApp/src/apps/Hello.js
@@ -1,7 +1,7 @@
 import gql from 'graphql-tag';
 import React from 'react';
-import styles from './hello.scss';
 
+import styles from './hello.scss';
 import Form from '../../../../../../lib/client/components/Form';
 
 export default () => {

--- a/test/integration/prod/prod.spec.js
+++ b/test/integration/prod/prod.spec.js
@@ -49,6 +49,11 @@ describe('Prod server', () => {
         .getCssProperty('div[class*="component"]', 'color')
         .value.indexOf('rgba(255,255,255,1)') >= -1
     ), 20000);
+    browser.waitUntil(() => (
+      browser
+        .getCssProperty('body', 'background')
+        .value.indexOf('rgba(0,255,0,1)') >= -1
+    ), 20000);
   });
 
   it('respects the custom webpack config', () => {

--- a/test/integration/prod/testApp/src/apps/Hello.js
+++ b/test/integration/prod/testApp/src/apps/Hello.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import styles from './hello.scss';
 
+import './simple.css';
+
 export default () => (
   <div className={styles.component}>Hello World</div>
 );

--- a/test/integration/prod/testApp/src/apps/simple.css
+++ b/test/integration/prod/testApp/src/apps/simple.css
@@ -1,0 +1,3 @@
+body {
+  background: rgb(0, 255, 0);
+}

--- a/test/integration/prod/testApp/src/config/babel.js
+++ b/test/integration/prod/testApp/src/config/babel.js
@@ -1,0 +1,7 @@
+export default (config, isServer) => {
+  if (isServer) {
+    config.plugins[0][1].extensions.push('.css');
+  }
+
+  return config;
+};

--- a/test/integration/prod/testApp/src/config/webpack.js
+++ b/test/integration/prod/testApp/src/config/webpack.js
@@ -5,5 +5,12 @@ export default (config) => {
     { from: `${__dirname}/test123.js` },
   ]));
 
+  config.module.loaders.push({
+    test: /\.css$/,
+    loaders: [
+      'style-loader', 'css-loader',
+    ],
+  });
+
   return config;
 };


### PR DESCRIPTION
You can now add a custom babel.js file into the config folder.
This allows you to override settings or replace them entirely.
We've also added a param to change how what the server would
use vs what the client would use for babel.