### PR TITLE
redirectTo now supports template strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.5.7] - 2017-10-10
+### Added
+- Since 0.5.0 we've improved Forms a-lot. This release continues improvemenets. redirectTo in particular is really usefule for leading from 1 gql form to the next page.
+- Ability to use template strings for redirectTo
+- Disabled "no-template-curly-in-string" from default eslint. This was done in order to support template strings for redirectTo
 
 ## [0.5.0] - 2017-09-27
 ### Added

--- a/src/client/components/formBuilder.js
+++ b/src/client/components/formBuilder.js
@@ -42,7 +42,10 @@ export default (mutation) => {
       })
       .then((res) => {
         if (this.props.redirectOnClient) {
-          this.props.pushAction(this.props.redirectTo);
+          const data = res.data; // eslint-disable-line
+          // This eval is fairly safe, it is always data the server "sanitizes"
+          const redirectPath = eval('`' + this.props.redirectTo + '`'); // eslint-disable-line
+          this.props.pushAction(redirectPath);
         }
 
         this.props.onSuccess(res);

--- a/src/server/formPost.js
+++ b/src/server/formPost.js
@@ -22,7 +22,11 @@ export default async (ctx) => {
         'Content-Type': 'application/json',
       },
     },
-  ).then(() => {
-    ctx.redirect(301, `${process.env.HOST || ctx.request.origin}/${redirectTo}`);
+  ).then((res) => res.json())
+  // data does get used, redirectTo could use `data` from the gql response
+  .then(({data}) => { // eslint-disable-line
+    // eslint-disable-next-line
+    const redirectPath = eval('`' + redirectTo + '`');
+    ctx.redirect(301, `${process.env.HOST || ctx.request.origin}/${redirectPath}`);
   });
 };

--- a/src/templates/newApp/.eslintrc
+++ b/src/templates/newApp/.eslintrc
@@ -12,6 +12,7 @@
         "arrow-parens": ["error", "always"],
         "indent": ["error", 2],
         "no-param-reassign": ["error", { "props": false }],
+        "no-template-curly-in-string": [0],
         "react/jsx-filename-extension": [1, { "extensions": [".js"] }],
         "react/jsx-indent": [2, 2],
         "react/jsx-indent-props": [2, 2],


### PR DESCRIPTION
These template strings are resolved once the gql returns.
To use response gql data, you should use the keyword `data`
then mimic the nesting of a gql response.

Example:
<From ... redirectTo="/group/${data.createGroup.group.id}">