### PR TITLE
Support hooking into the server and client rendering cycle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ errorShots
 test/integration/prod/testApp/build
 test/integration/prodNoJS/testApp/build
 test/unit/cli/build
+.vscode

--- a/src/client/main.js
+++ b/src/client/main.js
@@ -14,6 +14,7 @@ import fervorRoutes from 'fervorAppRoutes';
 import browserHistory from './history';
 import store from './store';
 import Routes from './routes';
+import load from '../shared/utils/load';
 
 const networkInterface = createNetworkInterface({ uri: '/graphql' });
 networkInterface.use([{
@@ -33,17 +34,34 @@ const webClient = new ApolloClient({
   networkInterface,
 });
 
+const rendering = load('config/rendering', {
+  options: {
+    appLocation: process.env.APP_LOCATION,
+  },
+  default: {
+    client: {
+      App: undefined,
+    },
+  },
+});
+
+const { App: AppWrapper } = rendering.client;
+
+
 const render = (Component, initialPath, startingComponent) => {
-  ReactDOM.hydrate(
-    (
-      <ApolloProvider client={webClient} store={store}>
-        <ConnectedRouter history={browserHistory}>
-          <Component initialPath={initialPath} startingComponent={startingComponent} />
-        </ConnectedRouter>
-      </ApolloProvider>
-    ),
-    document.querySelector('#app'),
+  let app = (
+    <ApolloProvider client={webClient} store={store}>
+      <ConnectedRouter history={browserHistory}>
+        <Component initialPath={initialPath} startingComponent={startingComponent} />
+      </ConnectedRouter>
+    </ApolloProvider>
   );
+
+  if (AppWrapper) {
+    app = <AppWrapper>{app}</AppWrapper>;
+  }
+
+  ReactDOM.hydrate(app, document.querySelector('#app'));
 };
 
 let startApp = () => render(Routes);

--- a/src/client/main.js
+++ b/src/client/main.js
@@ -39,14 +39,15 @@ const rendering = load('config/rendering', {
     appLocation: process.env.APP_LOCATION,
   },
   default: {
-    client: {
-      App: undefined,
+    default: {
+      client: {
+        App: undefined,
+      },
     },
   },
 });
 
-const { App: AppWrapper } = rendering.client;
-
+const { App: AppWrapper } = rendering.default.client;
 
 const render = (Component, initialPath, startingComponent) => {
   let app = (

--- a/src/client/main.js
+++ b/src/client/main.js
@@ -14,7 +14,6 @@ import fervorRoutes from 'fervorAppRoutes';
 import browserHistory from './history';
 import store from './store';
 import Routes from './routes';
-import load from '../shared/utils/load';
 
 const networkInterface = createNetworkInterface({ uri: '/graphql' });
 networkInterface.use([{
@@ -34,20 +33,13 @@ const webClient = new ApolloClient({
   networkInterface,
 });
 
-const rendering = load('config/rendering', {
-  options: {
-    appLocation: process.env.APP_LOCATION,
-  },
-  default: {
-    default: {
-      client: {
-        App: undefined,
-      },
-    },
-  },
-});
-
-const { App: AppWrapper } = rendering.default.client;
+let rendering;
+try {
+  // eslint-disable-next-line
+  rendering = require('fervorConfig/rendering');
+} catch (err) {
+  rendering = { default: { client: { App: undefined } } };
+}
 
 const render = (Component, initialPath, startingComponent) => {
   let app = (
@@ -58,6 +50,7 @@ const render = (Component, initialPath, startingComponent) => {
     </ApolloProvider>
   );
 
+  const { App: AppWrapper } = rendering.default.client;
   if (AppWrapper) {
     app = <AppWrapper>{app}</AppWrapper>;
   }

--- a/src/config/webpack.dev.js
+++ b/src/config/webpack.dev.js
@@ -13,6 +13,7 @@ export default (app, options) => {
     resolve: {
       alias: {
         fervorAppRoutes: path.resolve(options.appLocation, 'src', 'urls.js'),
+        fervorConfig: path.resolve(options.appLocation, 'src', 'config'),
       },
     },
     entry: [
@@ -90,7 +91,6 @@ export default (app, options) => {
         'process.env': {
           BROWSER: JSON.stringify(true),
           HOST: JSON.stringify(process.env.HOST),
-          APP_LOCATION: JSON.stringify(process.cwd()),
         },
       }),
       new webpack.DllReferencePlugin({

--- a/src/config/webpack.dev.js
+++ b/src/config/webpack.dev.js
@@ -90,6 +90,7 @@ export default (app, options) => {
         'process.env': {
           BROWSER: JSON.stringify(true),
           HOST: JSON.stringify(process.env.HOST),
+          APP_LOCATION: JSON.stringify(process.cwd()),
         },
       }),
       new webpack.DllReferencePlugin({

--- a/src/config/webpack.prod.js
+++ b/src/config/webpack.prod.js
@@ -112,6 +112,7 @@ module.exports = () => {
           NODE_ENV: JSON.stringify('production'),
           BROWSER: JSON.stringify(true),
           HOST: JSON.stringify(process.env.HOST),
+          APP_LOCATION: JSON.stringify(process.cwd()),
         },
       }),
       new webpack.DllReferencePlugin({

--- a/src/config/webpack.prod.js
+++ b/src/config/webpack.prod.js
@@ -37,6 +37,7 @@ module.exports = () => {
     resolve: {
       alias: {
         fervorAppRoutes: path.resolve(process.cwd(), 'src', 'urls.js'),
+        fervorConfig: path.resolve(process.cwd(), 'src', 'config'),
       },
     },
     entry: {
@@ -112,7 +113,6 @@ module.exports = () => {
           NODE_ENV: JSON.stringify('production'),
           BROWSER: JSON.stringify(true),
           HOST: JSON.stringify(process.env.HOST),
-          APP_LOCATION: JSON.stringify(process.cwd()),
         },
       }),
       new webpack.DllReferencePlugin({

--- a/src/server/components/Document.js
+++ b/src/server/components/Document.js
@@ -81,7 +81,7 @@ export default function Document({
       </head>
       <body>
         <div id="app" dangerouslySetInnerHTML={{ __html: content }} />
-        <div dangerouslySetInnerHTML={{ __html: additionalContent }} />
+        { additionalContent }
         <script
           dangerouslySetInnerHTML={{
             __html: `window.APOLLO_STATE=${JSON.stringify(state).replace(/</g, '\\u003c')};`,
@@ -97,7 +97,7 @@ Document.defaultProps = {
   appFavicon: null,
   manifest: {},
   title: '',
-  additionalContent: '',
+  additionalContent: null,
 };
 
 Document.propTypes = {
@@ -107,5 +107,5 @@ Document.propTypes = {
   content: PropTypes.string.isRequired,
   state: PropTypes.object.isRequired,
   title: PropTypes.string,
-  additionalContent: PropTypes.string,
+  additionalContent: PropTypes.node,
 };

--- a/src/server/components/Document.js
+++ b/src/server/components/Document.js
@@ -9,6 +9,7 @@ export default function Document({
   manifest,
   state,
   title,
+  additionalContent,
 }) {
   let scripts = [
     <script key="bundle.js" src="/build/bundle.js" />,
@@ -80,6 +81,7 @@ export default function Document({
       </head>
       <body>
         <div id="app" dangerouslySetInnerHTML={{ __html: content }} />
+        <div dangerouslySetInnerHTML={{ __html: additionalContent }} />
         <script
           dangerouslySetInnerHTML={{
             __html: `window.APOLLO_STATE=${JSON.stringify(state).replace(/</g, '\\u003c')};`,
@@ -95,6 +97,7 @@ Document.defaultProps = {
   appFavicon: null,
   manifest: {},
   title: '',
+  additionalContent: '',
 };
 
 Document.propTypes = {
@@ -104,4 +107,5 @@ Document.propTypes = {
   content: PropTypes.string.isRequired,
   state: PropTypes.object.isRequired,
   title: PropTypes.string,
+  additionalContent: PropTypes.string,
 };

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -2,7 +2,6 @@ import bodyParser from 'koa-bodyparser';
 import chalk from 'chalk';
 import cookie from 'koa-cookie';
 import cors from 'kcors';
-import fs from 'fs';
 import requestLogger from 'koa-logger-winston';
 import Koa from 'koa';
 import postgraphile from 'postgraphile';
@@ -21,7 +20,9 @@ export default async function startApp(options = {}) {
   const pgqlOpts = { graphiql: false };
 
   // load user defined graphQL options
-  const graphOptions = load('graph', { options, default: {} });
+  const graph = load('graph', { options, default: { default: () => ({}) } });
+  const graphOptions = graph.default();
+
   if (graphOptions.graphqlRoute) {
     logger.warn('Changing the graphqlRoute is disabled. We\'ve reverted it back to /graphql');
   }
@@ -37,7 +38,9 @@ export default async function startApp(options = {}) {
   app.use(cookie());
 
   // load any user defined middleware
-  load('middleware', { args: { app, logger, options }, options });
+  const middleware = load('middleware', { options, default: () => {} });
+  middleware.default({ app, logger, options });
+
   app.use(appManifest(options));
   app.use(ssr(options));
   if (!options.disableWebpack) {

--- a/src/server/ssr.js
+++ b/src/server/ssr.js
@@ -101,14 +101,16 @@ export default (options, Doc = Document) => {
       app = <AppWrapper options={appOptions}>{app}</AppWrapper>;
     }
 
-    let additionalDocumentContent;
-    if (getAdditionalDocumentContent) {
-      additionalDocumentContent = getAdditionalDocumentContent(appOptions);
-    }
-
     return getDataFromTree(app).then(() => {
       const state = store.getState();
       state.apollo = serverClient.getInitialState();
+      const content = ReactDOMServer.renderToString(app);
+
+      // Load additional document content after rendering the app. We do this after rendering the app to support hooks compiling the necessary styles to render the app.
+      let additionalDocumentContent;
+      if (getAdditionalDocumentContent) {
+        additionalDocumentContent = getAdditionalDocumentContent(appOptions);
+      }
 
       // TODO: app.props.title is not accessible on the server-side.
       // For now we'll just rely on it getting set client side.
@@ -119,7 +121,7 @@ export default (options, Doc = Document) => {
           appFavicon={options.appFavicon}
           // eslint-disable-next-line
           manifest={require(`${options.appLocation}/src/config/appmanifest.json`)}
-          content={ReactDOMServer.renderToString(app)}
+          content={content}
           state={state}
           title={app.props.title}
           additionalContent={additionalDocumentContent}

--- a/src/server/ssr.js
+++ b/src/server/ssr.js
@@ -67,10 +67,12 @@ export default (options, Doc = Document) => {
     const rendering = load('config/rendering', {
       options,
       default: {
-        server: {
-          getAppOptions: undefined,
-          App: undefined,
-          getAdditionalDocumentContent: undefined,
+        default: {
+          server: {
+            getAppOptions: undefined,
+            App: undefined,
+            getAdditionalDocumentContent: undefined,
+          },
         },
       },
     });
@@ -88,12 +90,13 @@ export default (options, Doc = Document) => {
       getAppOptions,
       App: AppWrapper,
       getAdditionalDocumentContent,
-    } = rendering.server;
+    } = rendering.default.server;
 
     let appOptions = {};
     if (getAppOptions) {
       appOptions = getAppOptions();
     }
+
     if (AppWrapper) {
       app = <AppWrapper options={appOptions}>{app}</AppWrapper>;
     }

--- a/src/shared/utils/load.js
+++ b/src/shared/utils/load.js
@@ -1,30 +1,31 @@
-import fs from 'fs';
-
 export default function load(
   name,
   { args = undefined, options = {}, default: _default = null },
 ) {
-  let module = _default;
-  if (
-    options.disableWebpack &&
-    (fs.existsSync(`${options.appLocation}/build/${name}.js`) ||
-      fs.existsSync(`${options.appLocation}/build/${name}/index.js`))
-  ) {
+  let module;
+  try {
     // eslint-disable-next-line global-require, import/no-dynamic-require
     module = require(`${options.appLocation}/build/${name}`);
-  } else if (
-    fs.existsSync(`${options.appLocation}/src/${name}.js`) ||
-    fs.existsSync(`${options.appLocation}/src/${name}/index.js`)
-  ) {
-    // eslint-disable-next-line global-require, import/no-dynamic-require
-    module = require(`${options.appLocation}/src/${name}`);
+  } catch (buildErr) {
+    try {
+      // eslint-disable-next-line global-require, import/no-dynamic-require
+      module = require(`${options.appLocation}/src/${name}`);
+    } catch (srcErr) {
+      module = undefined;
+    }
   }
 
   let res;
-  if (args !== undefined) {
-    res = module.default(args);
-  } else {
-    res = module.default();
+  if (module !== undefined) {
+    if (args !== undefined) {
+      res = module.default(args);
+    } else {
+      res = module.default();
+    }
+  }
+
+  if (res === undefined) {
+    res = _default;
   }
 
   return res;

--- a/src/shared/utils/load.js
+++ b/src/shared/utils/load.js
@@ -1,6 +1,6 @@
 export default function load(
   name,
-  { args = undefined, options = {}, default: _default = null },
+  { options = {}, default: _default = null },
 ) {
   let module;
   try {
@@ -11,22 +11,9 @@ export default function load(
       // eslint-disable-next-line global-require, import/no-dynamic-require
       module = require(`${options.appLocation}/src/${name}`);
     } catch (srcErr) {
-      module = undefined;
+      module = _default;
     }
   }
 
-  let res;
-  if (module !== undefined) {
-    if (args !== undefined) {
-      res = module.default(args);
-    } else {
-      res = module.default();
-    }
-  }
-
-  if (res === undefined) {
-    res = _default;
-  }
-
-  return res;
+  return module;
 }

--- a/src/shared/utils/load.js
+++ b/src/shared/utils/load.js
@@ -1,0 +1,31 @@
+import fs from 'fs';
+
+export default function load(
+  name,
+  { args = undefined, options = {}, default: _default = null },
+) {
+  let module = _default;
+  if (
+    options.disableWebpack &&
+    (fs.existsSync(`${options.appLocation}/build/${name}.js`) ||
+      fs.existsSync(`${options.appLocation}/build/${name}/index.js`))
+  ) {
+    // eslint-disable-next-line global-require, import/no-dynamic-require
+    module = require(`${options.appLocation}/build/${name}`);
+  } else if (
+    fs.existsSync(`${options.appLocation}/src/${name}.js`) ||
+    fs.existsSync(`${options.appLocation}/src/${name}/index.js`)
+  ) {
+    // eslint-disable-next-line global-require, import/no-dynamic-require
+    module = require(`${options.appLocation}/src/${name}`);
+  }
+
+  let res;
+  if (args !== undefined) {
+    res = module.default(args);
+  } else {
+    res = module.default();
+  }
+
+  return res;
+}


### PR DESCRIPTION
This PR adds support for users hooking into the server and client rendering cycle.

We'll look for a `config/rendering.js` file with the following export:

```
export default {
  server: {
    getAdditionalDocumentContent,
    getAppOptions,
    App: ServerApp
  },
  client: {
    App: ClientApp
  }
}
```

- `server.getAppOptions` is a function that can return options that will be passed through to: `server.App` and `server.getAdditionalDocumentContent`
- `server.App` is an optional component that the user can specify to wrap the default fervorous server app
- `server.getAdditionalDocumentContent` is a function that will be passed the options returned from `server.getAppOptions` which can return additional content to inject into the ferverous Document.

this can be used to support [Material-UI](https://material-ui-next.com/guides/server-rendering/)

```
import React from "react"
import JssProvider from "react-jss/lib/JssProvider"
import { SheetsRegistry } from "react-jss/lib/jss"
import { create } from "jss"
import preset from "jss-preset-default"
import { MuiThemeProvider, createMuiTheme } from "material-ui/styles"
import createGenerateClassName from "material-ui/styles/createGenerateClassName"

const theme = createMuiTheme()

function getAppOptions() {
  const jss = create(preset())
  jss.options.createGenerateClassName = createGenerateClassName
  const sheetsRegistry = new SheetsRegistry()

  return {
    theme,
    jss,
    sheetsRegistry
  }
}

const ServerApp = ({ children, options: { sheetsRegistry, jss, theme } }) => {
  return (
    <JssProvider registry={sheetsRegistry} jss={jss}>
      <MuiThemeProvider theme={theme} sheetsManager={new Map()}>
        {children}
      </MuiThemeProvider>
    </JssProvider>
  )
}

function getAdditionalDocumentContent({ sheetsRegistry }) {
  return (
    <style
      id="jss-server-side"
      dangerouslySetInnerHTML={{ __html: sheetsRegistry.toString() }}
    />
  )
}

class SSRCleanup extends React.Component {
  componentDidMount() {
    const jssStyles = document.getElementById("jss-server-side")
    if (jssStyles && jssStyles.parentNode) {
      jssStyles.parentNode.removeChild(jssStyles)
    }
  }

  render() {
    return this.props.children
  }
}

const ClientApp = ({ children }) => (
  <MuiThemeProvider theme={theme}>
    <SSRCleanup>{children}</SSRCleanup>
  </MuiThemeProvider>
)

export default {
  server: {
    getAdditionalDocumentContent,
    getAppOptions,
    App: ServerApp
  },
  client: {
    App: ClientApp
  }
}
```