### PR TITLE
Tweaked how the config free SSR setup works

### DIFF
--- a/src/client/main.js
+++ b/src/client/main.js
@@ -10,6 +10,8 @@ import ReactDOM from 'react-dom';
 import { ConnectedRouter } from 'react-router-redux';
 // eslint-disable-next-line
 import fervorRoutes from 'fervorAppRoutes';
+// eslint-disable-next-line
+import fervorConfigRendering from 'fervorConfigRendering';
 
 import browserHistory from './history';
 import store from './store';
@@ -32,14 +34,6 @@ const webClient = new ApolloClient({
   initialState: { apollo: window.APOLLO_STATE.apollo },
   networkInterface,
 });
-
-let rendering;
-try {
-  // eslint-disable-next-line
-  rendering = require('fervorConfig/rendering');
-} catch (err) {
-  rendering = { default: { client: { App: undefined } } };
-}
 
 const render = (Component, initialPath, startingComponent) => {
   let app = (

--- a/src/config/renderingConfig.js
+++ b/src/config/renderingConfig.js
@@ -1,0 +1,1 @@
+export default { client: { App: undefined } };

--- a/src/config/webpack.dev.js
+++ b/src/config/webpack.dev.js
@@ -6,14 +6,18 @@ import webpack from 'webpack';
 import webpackMiddleware from 'koa-webpack';
 import WorkboxPlugin from 'workbox-webpack-plugin';
 
+import hasConfig from '../shared/utils/hasConfig';
 import logger from '../shared/utils/logger';
 
 export default (app, options) => {
+  const hasRenderingConfig = hasConfig(options.appLocation, 'rendering');
   let devConfig = {
     resolve: {
       alias: {
         fervorAppRoutes: path.resolve(options.appLocation, 'src', 'urls.js'),
-        fervorConfig: path.resolve(options.appLocation, 'src', 'config'),
+        fervorConfigRendering: hasRenderingConfig ?
+          path.join(options.appLocation, 'src', 'config', 'rendering.js') :
+          path.join(__dirname, 'renderingConfig.js'),
       },
     },
     entry: [

--- a/src/config/webpack.prod.js
+++ b/src/config/webpack.prod.js
@@ -10,6 +10,7 @@ const globToRegExp = require('glob-to-regexp');
 const flexbugs = require('postcss-flexbugs-fixes');
 const webpack = require('webpack');
 const WorkboxPlugin = require('workbox-webpack-plugin');
+const hasConfig = require('../shared/utils/hasConfig');
 const ChunkManifestPlugin = require('./ChunkManifestPlugin');
 const clientSideBabelConfig = require('./babelrcHelper').default(false, process.cwd(), true);
 
@@ -33,11 +34,15 @@ if (process.env.TEST_ENV !== 'integration') {
 }
 
 module.exports = () => {
+  const hasRenderingConfig = hasConfig.default(process.cwd(), 'rendering');
+
   let prodConfig = {
     resolve: {
       alias: {
         fervorAppRoutes: path.resolve(process.cwd(), 'src', 'urls.js'),
-        fervorConfig: path.resolve(process.cwd(), 'src', 'config'),
+        fervorConfigRendering: hasRenderingConfig ?
+          path.join(process.cwd(), 'src', 'config', 'rendering.js') :
+          path.join(__dirname, 'renderingConfig.js'),
       },
     },
     entry: {

--- a/src/server/ssr.js
+++ b/src/server/ssr.js
@@ -106,7 +106,9 @@ export default (options, Doc = Document) => {
       state.apollo = serverClient.getInitialState();
       const content = ReactDOMServer.renderToString(app);
 
-      // Load additional document content after rendering the app. We do this after rendering the app to support hooks compiling the necessary styles to render the app.
+      // Load additional document content after rendering the app.
+      // We do this after rendering the app to support hooks compiling
+      // the necessary styles to render the app.
       let additionalDocumentContent;
       if (getAdditionalDocumentContent) {
         additionalDocumentContent = getAdditionalDocumentContent(appOptions);

--- a/src/shared/utils/hasConfig.js
+++ b/src/shared/utils/hasConfig.js
@@ -1,0 +1,6 @@
+const fs = require('fs');
+
+export default (appLocation, configName) => (
+  fs.existsSync(`${appLocation}/src/config/${configName}.js`) ||
+  fs.existsSync(`${appLocation}/src/config/${configName}/index.js`)
+);

--- a/test/integration/dev/dev.spec.js
+++ b/test/integration/dev/dev.spec.js
@@ -60,4 +60,10 @@ describe('Dev server', () => {
     const response = await superagent.get('http://localhost:3002/pizza');
     expect(response.text).to.contain('Pizza World');
   });
+
+  it('takes advantage of a rendering wrapper', async () => {
+    const response = await superagent.get('http://localhost:3002/');
+    expect(response.text).to.contain('Test Wrapper');
+    expect(response.text).to.contain('Additional Content');
+  });
 });

--- a/test/integration/dev/testApp/src/config/rendering.js
+++ b/test/integration/dev/testApp/src/config/rendering.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const App = ({ children }) => (
+  <div>
+    Test Wrapper
+    {children}
+  </div>
+);
+
+App.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export default {
+  server: {
+    getAdditionalDocumentContent: () => (
+      <span style={{ display: 'none' }}>Additional Content</span>
+    ),
+    App,
+  },
+  client: {
+    App,
+  },
+};


### PR DESCRIPTION
Replaced the fervorConfig alias for a fervorConfigRendering
alias and provided a default config file. This is all defined
in the webpack config as opposed to the client code.