### PR TITLE
Add missing dependency - `react-hot-loader`

### DIFF
--- a/src/templates/newApp/package.json
+++ b/src/templates/newApp/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
-    "fervor": "^0.6.0"
+    "fervor": "^0.6.0",
+    "react-hot-loader": "^3.1.3"
   }
 }


### PR DESCRIPTION
react-hot-loader is a missing dependency, without this change you get the below error.

![1__node_and_comparing_fervorous_master___albybarber_alby-add-dependency_ _fervorous_fervor](https://user-images.githubusercontent.com/462491/35029120-3ea07ca2-fb0e-11e7-9d92-42c4d6ebc46f.png)

