### PR TITLE
Added a Meta component via react-helmet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2018-06-02
+### Added
+- Added react-helmet and our "Meta" facade for it. You can now use it as superior alternative to our original "Document" component.
+- Titles are now renderable server side :boom:
+- All meta data on the page is editable
+### Changed
+- Our "Document" component is deprecated and will be removed in the future
+### Removed
+- IMPORTANT (breaking change): We no longer automatically add the "viewport" meta tag. If you were using this previously you should manually add it to your site. You can add it like this in your templates or for any app.
+  <Meta>
+    <meta key="viewport" name="viewport" content="width=device-width, initial-scale=1" />
+  </Meta>
+
 ## [1.0.1] - 2018-05-15
 ### Changed
 - Use style-loader again for dev

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "react": "^16.3.1",
     "react-apollo": "^2.1.2",
     "react-dom": "^16.2.0",
+    "react-helmet": "^5.2.0",
     "react-hot-loader": "^4.0.1",
     "react-redux": "^5.0.7",
     "react-router": "^4.2.0",

--- a/src/client/components/Document.js
+++ b/src/client/components/Document.js
@@ -4,6 +4,8 @@ import React from 'react';
 export default class Document extends React.Component {
 
   componentDidMount() {
+    // eslint-disable-next-line
+    console.warn('The Document component in Fervor is now deprecated and will be removed in the future. Please use `Meta` instead. See https://github.com/fervorous/fervor/blob/master/CHANGELOG.md#110---2018-06-02 for more details.');
     document.querySelector('title').innerText = this.props.title;
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import clientCookies from 'cookies-js';
 import { compose, Query, Mutation, graphql } from 'react-apollo';
+import { Helmet } from 'react-helmet';
 import gql from 'graphql-tag';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
@@ -36,5 +37,6 @@ module.exports = {
   React,
 
   Document,
+  Meta: Helmet,
   Form,
 };

--- a/src/server/components/Document.js
+++ b/src/server/components/Document.js
@@ -1,11 +1,13 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import { Helmet } from 'react-helmet';
 
 /* eslint-disable react/no-danger */
 export default function Document({
   appFavicon,
   appLocation,
   content,
+  helmet,
   manifest,
   state,
   title,
@@ -73,17 +75,22 @@ export default function Document({
     pwaMeta.push(<meta key="appThemeColor" name="theme-color" content={manifest.theme_color} />);
   }
 
+  const htmlAttrs = helmet.htmlAttributes.toComponent();
+  const bodyAttrs = helmet.bodyAttributes.toComponent();
+
   return (
-    <html lang="en">
+    <html lang="en" {...htmlAttrs}>
       <head>
-        <title>{title}</title>
+        {title ? <title>{title}</title> : null}
+        {helmet.title.toComponent()}
+        {helmet.meta.toComponent()}
         { processMeta(pwaMeta.concat([
           <link key="appManifest" rel="manifest" href="/appmanifest.json" />,
-          <meta key="viewport" name="viewport" content="width=device-width, initial-scale=1" />,
-        ])) }
+        ]))}
+        {helmet.link.toComponent()}
         { processCSS(cssFiles) }
       </head>
-      <body>
+      <body {...bodyAttrs}>
         <div id="app" dangerouslySetInnerHTML={{ __html: content }} />
         { additionalContent }
         <script
@@ -112,6 +119,7 @@ Document.propTypes = {
   appFavicon: PropTypes.string,
   manifest: PropTypes.object,
   content: PropTypes.string.isRequired,
+  helmet: PropTypes.object.isRequired,
   state: PropTypes.object.isRequired,
   title: PropTypes.string,
   additionalContent: PropTypes.node,

--- a/src/server/processRoute.js
+++ b/src/server/processRoute.js
@@ -5,6 +5,7 @@ import { createHttpLink } from 'apollo-link-http';
 import { setContext } from 'apollo-link-context';
 import { InMemoryCache } from 'apollo-cache-inmemory';
 import { ApolloProvider, getDataFromTree } from 'react-apollo';
+import { Helmet } from 'react-helmet';
 import { Provider } from 'react-redux';
 import ReactDOMServer from 'react-dom/server';
 import { StaticRouter } from 'react-router';
@@ -115,6 +116,7 @@ export default async (options, ctx, next, Doc = Document) => {
     const state = store.getState();
     state.apollo = serverClient.extract();
     const content = ReactDOMServer.renderToString(app);
+    const helmet = Helmet.renderStatic();
 
     // Load additional document content after rendering the app.
     // We do this after rendering the app to support hooks compiling
@@ -124,9 +126,6 @@ export default async (options, ctx, next, Doc = Document) => {
       additionalDocumentContent = getAdditionalDocumentContent(appOptions);
     }
 
-    // TODO: app.props.title is not accessible on the server-side.
-    // For now we'll just rely on it getting set client side.
-
     ctx.body = `<!doctype html>\n${ReactDOMServer.renderToStaticMarkup((
       <Doc
         appLocation={options.appLocation}
@@ -134,6 +133,7 @@ export default async (options, ctx, next, Doc = Document) => {
         // eslint-disable-next-line
         manifest={require(`${options.appLocation}/src/config/appmanifest.json`)}
         content={content}
+        helmet={helmet}
         state={state}
         title={app.props.title}
         additionalContent={additionalDocumentContent}

--- a/src/templates/newApp/src/components/Template.js
+++ b/src/templates/newApp/src/components/Template.js
@@ -1,8 +1,12 @@
-import { Document, React, PropTypes } from 'fervor/lib';
+import { Meta, React, PropTypes } from 'fervor/lib';
 import styles from './styles/template.scss';
 
 const Template = ({ children, title }) => (
-  <Document title={title}>
+  <React.Fragment>
+    <Meta>
+      <title>{title}</title>
+      <meta key="viewport" name="viewport" content="width=device-width, initial-scale=1" />,
+    </Meta>
     <div className={styles.demoapp}>
       <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet" />
       <header>
@@ -12,7 +16,7 @@ const Template = ({ children, title }) => (
         {children}
       </div>
     </div>
-  </Document>
+  </React.Fragment>
 );
 
 Template.propTypes = {

--- a/test/integration/prod/prod.spec.js
+++ b/test/integration/prod/prod.spec.js
@@ -35,6 +35,7 @@ describe('Prod server', () => {
   it('renders server side', async () => {
     const response = await superagent.get('http://localhost:3003/');
     expect(response.text).to.contain('Hello World');
+    expect(response.text).to.contain('Testing</title>');
   });
 
   it('renders client side with CSS', () => {

--- a/test/integration/prod/testApp/src/apps/Hello.js
+++ b/test/integration/prod/testApp/src/apps/Hello.js
@@ -1,8 +1,14 @@
 import React from 'react';
+import { Helmet as Meta } from 'react-helmet';
 import styles from './hello.scss';
 
 import './simple.css';
 
 export default () => (
-  <div className={styles.component}>Hello World</div>
+  <React.Fragment>
+    <Meta>
+      <title>Testing</title>
+    </Meta>
+    <div className={styles.component}>Hello World</div>
+  </React.Fragment>
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -3281,6 +3281,10 @@ execa@^0.7.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
+exenv@^1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/exenv/-/exenv-1.2.2.tgz#2ae78e85d9894158670b03d47bec1f03bd91bb9d"
+
 exit-hook@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
@@ -7839,6 +7843,15 @@ react-dom@^16.2.0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
+react-helmet@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/react-helmet/-/react-helmet-5.2.0.tgz#a81811df21313a6d55c5f058c4aeba5d6f3d97a7"
+  dependencies:
+    deep-equal "^1.0.1"
+    object-assign "^4.1.1"
+    prop-types "^15.5.4"
+    react-side-effect "^1.1.0"
+
 react-hot-loader@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/react-hot-loader/-/react-hot-loader-4.0.1.tgz#48284350ae5d7ba07dac872bd5bbc6e477352593"
@@ -7903,6 +7916,13 @@ react-router@^4.2.0:
     path-to-regexp "^1.7.0"
     prop-types "^15.5.4"
     warning "^3.0.0"
+
+react-side-effect@^1.1.0:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-1.1.5.tgz#f26059e50ed9c626d91d661b9f3c8bb38cd0ff2d"
+  dependencies:
+    exenv "^1.2.1"
+    shallowequal "^1.0.1"
 
 react-test-renderer@^16.0.0-0, react-test-renderer@^16.3.1:
   version "16.3.1"
@@ -8675,7 +8695,7 @@ shallow-clone@^1.0.0:
     kind-of "^5.0.0"
     mixin-object "^2.0.1"
 
-shallowequal@^1.0.2:
+shallowequal@^1.0.1, shallowequal@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.0.2.tgz#1561dbdefb8c01408100319085764da3fcf83f8f"
 


### PR DESCRIPTION
This allows us to add arbitrary meta data to the page. This fixes a few
issues. 1) you couldn't add meta viewport data manually. 2) we had a
default viewport that wasn't overridable. 3) titles didn't render server
side. 4) you couldn't add scripts/styles into head as you wished.